### PR TITLE
Fix critical script errors

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,7 +11,7 @@ PROFILE="${DOTFILES_PROFILE:-minimal}"
 BRANCH="${DOTFILES_BRANCH:-main}"
 MACOS_DEFAULTS="${DOTFILES_MACOS_DEFAULTS:-true}"
 NO_GIT="${DOTFILES_NO_GIT:-false}"
-if [ "$USE_SSH" = "true"]; then
+if [ "$USE_SSH" = "true" ]; then
   REPO_URL="$SSH_REPO_URL"
 fi
 

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -30,8 +30,9 @@ setup_git_author() {
   fi
 
   # Update git remote URL to SSH
-  if [ "$(git remote get-url origin)" != "git@github\.com:dhavalsavalia/dotfiles\.git" ]; then
-    execute "git remote set-url origin git@github.com:dhavalsavalia/dotfiles.git"
+  current_url="$(git -C "$DOTFILES_DIR" remote get-url origin 2>/dev/null || echo "")"
+  if [ "$current_url" != "git@github.com:dhavalsavalia/dotfiles.git" ]; then
+    execute "git -C \"$DOTFILES_DIR\" remote set-url origin git@github.com:dhavalsavalia/dotfiles.git"
   fi
 
   # Check if user.conf already exists

--- a/scripts/stow.sh
+++ b/scripts/stow.sh
@@ -27,7 +27,7 @@ setup_stow() {
     for package in "${packages[@]}"; do
         if [ -d "$DOTFILES_DIR/$package" ]; then
             execute "cd $DOTFILES_DIR && stow -D $package" # Unstow first to ensure idempotency
-            execute "cd $DOTFILES_DIR && stow -t $HOME $package" --adopt
+            execute "cd $DOTFILES_DIR && stow -t $HOME --adopt $package"
         else
             warning "$package directory does not exist in $DOTFILES_DIR"
         fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -108,7 +108,7 @@ test_profile_packages() {
         for package in "${home_packages[@]}"; do
             check_brew_package "$package" || ((failed++))
         done
-    elif [ "$profile" = "1" ]; then
+    elif [ "$profile" = "garda" ]; then
         for package in "${work_packages[@]}"; do
             check_brew_package "$package" || ((failed++))
         done
@@ -126,8 +126,8 @@ main() {
     local total_failed=0
 
     # Validate profile
-    if [ "$profile" != "home" ] && [ "$profile" != "1" ]; then
-        error "Profile must be either 'home' or '1'"
+    if [ "$profile" != "home" ] && [ "$profile" != "garda" ]; then
+        error "Profile must be either 'home' or 'garda'"
         exit 1
     fi
 


### PR DESCRIPTION
## Summary
- Fix bash syntax error in `bootstrap.sh` (missing space before `]`)
- Fix `stow --adopt` flag placement in `stow.sh` (was standalone, now properly passed to stow command)
- Fix git remote URL check in `git.sh` (use proper string comparison instead of broken regex)
- Update test.sh profile names from "1" to "garda" to match actual profile system

## Impact
These are **critical fixes** that prevent script failures:
- `bootstrap.sh` would fail when `USE_SSH=true` is set
- `stow.sh` was not properly adopting existing configs
- `git.sh` remote URL check was always evaluating to true
- `test.sh` was completely broken for work profile validation

## Test plan
- [ ] Run `./bootstrap.sh` with `USE_SSH=true` (should not fail)
- [ ] Run `./scripts/stow.sh` on existing config (should adopt properly)
- [ ] Run `./scripts/git.sh` and verify remote URL check works
- [ ] Run `./scripts/test.sh -p garda` (should recognize profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)