### PR TITLE
feat: refine workspace layout and add dedicated Outlook workspace

### DIFF
--- a/aerospace/.config/aerospace/aerospace.toml
+++ b/aerospace/.config/aerospace/aerospace.toml
@@ -15,8 +15,8 @@ enable-normalization-opposite-orientation-for-nested-containers = false
 ### Layout Settings
 accordion-padding = 20
 default-root-container-layout = 'tiles'
-# Auto orientation: horizontal for wide monitors, vertical for tall monitors
-default-root-container-orientation = 'auto'
+# Horizontal orientation: side-by-side 50/50 splits on all displays
+default-root-container-orientation = 'horizontal'
 
 # I just wanted to remind myself
 # to use cmh+h more often and cmd+tab my way through getting it back.
@@ -70,12 +70,13 @@ alt-space = [
 
 # Workspace Navigation
 alt-b = 'workspace B' # Browser
-alt-c = 'workspace C' # Communication
-alt-d = 'workspace D' # Development
+alt-c = 'workspace C' # Communication (Teams)
+alt-d = 'workspace D' # Development (VSCode #1)
 alt-t = 'workspace T' # Terminal
 alt-a = 'workspace A' # API Tools
-alt-m = 'workspace M' # Music
-alt-x = 'workspace X' # Extra
+alt-o = 'workspace O' # Outlook
+alt-m = 'workspace M' # More Dev (VSCode #2)
+alt-x = 'workspace X' # Extra (VSCode #3+)
 
 # Move windows to workspaces
 alt-shift-b = ['move-node-to-workspace B', 'workspace B']
@@ -83,6 +84,7 @@ alt-shift-c = ['move-node-to-workspace C', 'workspace C']
 alt-shift-d = ['move-node-to-workspace D', 'workspace D']
 alt-shift-t = ['move-node-to-workspace T', 'workspace T']
 alt-shift-a = ['move-node-to-workspace A', 'workspace A']
+alt-shift-o = ['move-node-to-workspace O', 'workspace O']
 alt-shift-m = ['move-node-to-workspace M', 'workspace M']
 alt-shift-x = ['move-node-to-workspace X', 'workspace X']
 
@@ -234,8 +236,12 @@ if.app-name-regex-substring = '(Arc|Chrome|Safari)'
 run = 'move-node-to-workspace B'
 
 [[on-window-detected]]
-if.app-name-regex-substring = '(Microsoft Teams|Outlook|Mail|WhatsApp|Messages|Slack|Zoom|Telegram|Discord)'
+if.app-name-regex-substring = '(Microsoft Teams|Mail|WhatsApp|Messages|Slack|Zoom|Telegram|Discord)'
 run = 'move-node-to-workspace C'
+
+[[on-window-detected]]
+if.app-name-regex-substring = 'Outlook'
+run = 'move-node-to-workspace O'
 
 [[on-window-detected]]
 if.app-name-regex-substring = 'Code|GitHub'


### PR DESCRIPTION
## Summary

Phase 2 workspace refinement: adds dedicated Outlook workspace and enforces horizontal layout preference across all displays.

## Changes

### New Workspace O for Outlook
- **Alt+O**: Navigate to Workspace O
- **Alt+Shift+O**: Move window to Workspace O
- Outlook auto-assigns to O (previously competed with Teams in C)
- Frees up Workspace C for Teams and other communication apps

### Horizontal Layout Enforcement
- Changed `default-root-container-orientation` from `'auto'` to `'horizontal'`
- All workspaces now default to side-by-side 50/50 splits
- Consistent behavior on both laptop and ultrawide
- User preference: side-by-side over top/bottom

### Updated Workspace Semantics
Clear purpose for each workspace:
- **B**: Browser
- **C**: Communication (Teams, Slack, etc. - Outlook moved out)
- **D**: Development (VSCode #1)
- **T**: Terminal (Zellij/Tmux sessions)
- **A**: API Tools (Postman, MongoDB Compass)
- **O**: Outlook (NEW - dedicated)
- **M**: More Dev (VSCode #2, repurposed from "Music")
- **X**: Extra (VSCode #3+, overflow)

## Benefits

- **Reduces workspace competition**: Teams and Outlook no longer fight for space in C
- **Predictable layout**: All workspaces use horizontal splits by default
- **Mental model clarity**: Each workspace has defined purpose
- **Flexibility maintained**: Can still quit Outlook to free up O if needed

## Testing

**Tested on ultrawide (3440x1440):**
- [x] AeroSpace restarts successfully
- [x] Workspace O accessible via Alt+O
- [x] Horizontal layout applies to all workspaces
- [x] All existing keybinds still functional

**To verify on next use:**
- [ ] Outlook auto-assigns to Workspace O
- [ ] Teams stays in Workspace C
- [ ] Horizontal splits work on laptop display

## Related

Part of Phase 2 from `docs/aerospace-workflow-analysis.md` roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)